### PR TITLE
`infra`/`shell`/`patch`: Source bash profile from `shell/` instead of home `~`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,4 @@ setup: shell
 
 shell:
 	echo 'starting Nix bash shell ...'
-	cp -rf shell/bash/.bashrc ~/.bashrc
-	cp -rf shell/bash/.bash_aliases ~/.bash_aliases
-	cp -rf shell/bash/.bash_profile ~/.bash_profile
 	nix-shell --pure

--- a/shell.nix
+++ b/shell.nix
@@ -41,6 +41,8 @@ pkgs.mkShellNoCC {
        https://raw.githubusercontent.com/git/git/master/contrib/completion/git-prompt.sh
 
      echo "~~~~~ Bash shell restart w/ profile, prompt, aliases, and more! ~~~~~"";
-     bash;
+     source shell/bash/.bashrc
+     source shell/bash/.bash_aliases
+     source shell/bash/.bash_profile
    '';
 }


### PR DESCRIPTION
# Rationale
Source bash profile from `nix-data-mesh` instead of home directory.